### PR TITLE
Rewrite esgg.from annotation into ocaml.from annotation

### DIFF
--- a/README.md
+++ b/README.md
@@ -71,6 +71,21 @@ Syntax for variables in template json files is as follows:
   - `$var?` for optional variable (minimal surrounding scope is conditionally expunged)
   - full form `$(var:hint)` where `hint` can be either `list` or `list?` currently
 
+## Reusing shared ATD definitions
+
+To reuse shared definitions using the `-shared <file.atd>` option, the `atd` file must have the `<esgg from="...">` annotation at the top of the file.
+The value of the annotation must correspond to the OCaml module containing the shared definitions.
+
+Example:
+```
+# file.atd
+
+<esgg from="Your_ocaml_module_name">
+
+...atd type definitions...
+```
+
+
 ## Elasticsearch features
 
 TODO document what is supported

--- a/atdgen.ml
+++ b/atdgen.ml
@@ -273,11 +273,13 @@ end
 
 let make_abstract ((_loc,annot),init) types =
   let esgg_section_name = "esgg" in
-  let module_name = Atd.Annot.get_opt_field ~parse:(fun s -> Some s) ~sections:[esgg_section_name] ~field:"from" annot in
-  let annot =
-    annot
-    |> List.filter (fun (section_name, _) -> section_name <> esgg_section_name)
-    |> Atd.Annot.set_field ~loc ~section:"ocaml" ~field:"from" module_name
+  let module_name_opt = Atd.Annot.get_opt_field ~parse:(fun s -> Some s) ~sections:[esgg_section_name] ~field:"from" annot in
+  let annot = 
+    let annot' = match module_name_opt with
+    | Some module_name ->  Atd.Annot.set_field ~loc ~section:"ocaml" ~field:"from" (Some module_name) annot
+    | None -> annot
+    in 
+    List.filter (fun (section_name, _) -> section_name <> esgg_section_name) annot'
   in
   types |> List.map begin fun t ->
     match List.find (fun i -> type_def_name i = type_def_name t) init with (* match by name, because initial types are not renamed *)

--- a/atdgen.ml
+++ b/atdgen.ml
@@ -272,6 +272,13 @@ end = struct
 end
 
 let make_abstract ((_loc,annot),init) types =
+  let esgg_section_name = "esgg" in
+  let module_name = Atd.Annot.get_opt_field ~parse:(fun s -> Some s) ~sections:[esgg_section_name] ~field:"from" annot in
+  let annot =
+    annot
+    |> List.filter (fun (section_name, _) -> section_name <> esgg_section_name)
+    |> Atd.Annot.set_field ~loc ~section:"ocaml" ~field:"from" module_name
+  in
   types |> List.map begin fun t ->
     match List.find (fun i -> type_def_name i = type_def_name t) init with (* match by name, because initial types are not renamed *)
     | exception Not_found -> t


### PR DESCRIPTION
## Motivation

Prior to the changes in this PR, the `esgg atd` command relied on atd files having the following header:

```
<ocaml from="module_name">

...atd type definitions...
```

However, the above header format no longer works since `atd` version [2.3.0](https://github.com/ahrefs/atd/blob/master/CHANGES.md#230-2022-03-10), which introduces a check that throws an error when an invalid annotation is detected. The above header format is invalid since the `<ocaml from=...>` annotation must be [positioned on the left-hand side of a type definition, after the type name](https://atd.readthedocs.io/en/latest/atdgen.html#field-from)

## Changes made in this PR

The required header is now
```
<esgg from="module_name">

...atd type definitions...
```

The changes made in this PR will then:
- Extract the module name specified in the `<esgg from=...>` annotation
- Filter out all `esgg` annotations
- Add an `<ocaml from=...>` annotation with value being the module name extracted earlier
- Perform codegen as usual