### PR TITLE
Remove `_esgg` from resulting query

### DIFF
--- a/derive.ml
+++ b/derive.ml
@@ -113,7 +113,7 @@ let derive mapping json =
       let c1 = List.concat @@ fst @@ List.split aggs in
       let c2 = Query.infer' extra q in
       let vars = Query.resolve_constraints mapping (c1 @ c2) in
-      let json = Tjson.(remove "query" @@ remove "aggregations" @@ remove "aggs" @@ remove "_esgg" json) in
+      let json = Tjson.(remove "query" @@ remove "aggregations" @@ remove "aggs" json) in
       (* handle optional variables outside of aggregation and query parts *)
       let json = Tjson.(map (function `Var var when var.optional -> `Optional ({label=var.name;vars=[var.name]}, `Var var) | x -> x) json) in
       let json = Tjson.add json ["query",q.json; "aggregations", agg_json] in

--- a/derive.ml
+++ b/derive.ml
@@ -113,7 +113,7 @@ let derive mapping json =
       let c1 = List.concat @@ fst @@ List.split aggs in
       let c2 = Query.infer' extra q in
       let vars = Query.resolve_constraints mapping (c1 @ c2) in
-      let json = Tjson.(remove "query" @@ remove "aggregations" @@ remove "aggs" json) in
+      let json = Tjson.(remove "query" @@ remove "aggregations" @@ remove "aggs" @@ remove "_esgg" json) in
       (* handle optional variables outside of aggregation and query parts *)
       let json = Tjson.(map (function `Var var when var.optional -> `Optional ({label=var.name;vars=[var.name]}, `Var var) | x -> x) json) in
       let json = Tjson.add json ["query",q.json; "aggregations", agg_json] in

--- a/query.ml
+++ b/query.ml
@@ -301,6 +301,8 @@ let filter_out_conf json =
   | j -> j
 
 let extract json =
+  let conf = extract_conf json in
+  let json = filter_out_conf json in
   match U.assoc "query" json with
   | q ->
     let extra = List.map (fun v -> On_var (v, Eq_type Int)) @@ List.filter_map (get_var json) ["size";"from"] in
@@ -318,8 +320,6 @@ let extract json =
       Get { id; return; }
     | _ -> fail "only variable id supported for get request"
     | exception _ ->
-      let conf = extract_conf json in
-      let json = filter_out_conf json in
       let ids =
         match U.assoc "docs" json with
         | `List l -> var_list_of_json ~desc:"mget docs" (`List (List.map U.(assoc "_id") l))

--- a/query.ml
+++ b/query.ml
@@ -20,9 +20,9 @@ type query_t =
 and query = { json : Tjson.t; query : query_t; cstrs : constraint_t list; }
 
 type t =
-| Search of { q : query; extra : constraint_t list; source : source_filter or_var option; fields : string list option; highlight : string list option; }
+| Search of { q : query; extra : constraint_t list; source : source_filter or_var option; fields : string list option; highlight : string list option; json: Tjson.t }
 | Mget of { ids: var_list; json: Tjson.t; conf: Tjson.t } (* get and mget probably can/should share most of the type? *)
-| Get of { id : Tjson.var; return : [ `Source of source_filter | `Fields of string list | `Nothing ] }
+| Get of { id : Tjson.var; return : [ `Source of source_filter | `Fields of string list | `Nothing ]; json: Tjson.t }
 
 module Variable = struct
 
@@ -306,7 +306,7 @@ let extract json =
   match U.assoc "query" json with
   | q ->
     let extra = List.map (fun v -> On_var (v, Eq_type Int)) @@ List.filter_map (get_var json) ["size";"from"] in
-    Search { q = extract_query q; extra; source = extract_source json; fields = extract_stored_fields json; highlight = extract_highlight json; }
+    Search { q = extract_query q; extra; source = extract_source json; fields = extract_stored_fields json; highlight = extract_highlight json; json }
   | exception _ ->
     match U.assoc "id" json with
     | `Var id ->
@@ -317,7 +317,7 @@ let extract json =
         | None, Some fields -> `Fields fields
         | None, None -> `Nothing
       in
-      Get { id; return; }
+      Get { id; return; json }
     | _ -> fail "only variable id supported for get request"
     | exception _ ->
       let ids =

--- a/query.mli
+++ b/query.mli
@@ -6,9 +6,9 @@ type query_t
 type var_list
 type query = { json : Tjson.t; query : query_t; cstrs : constraint_t list; }
 type t =
-| Search of { q : query; extra : constraint_t list; source : source_filter or_var option; fields : string list option; highlight : string list option; }
+| Search of { q : query; extra : constraint_t list; source : source_filter or_var option; fields : string list option; highlight : string list option; json: Tjson.t }
 | Mget of { ids: var_list; json: Tjson.t; conf: Tjson.t }
-| Get of { id : Tjson.var; return : [ `Source of source_filter | `Fields of string list | `Nothing ] }
+| Get of { id : Tjson.var; return : [ `Source of source_filter | `Fields of string list | `Nothing ]; json: Tjson.t }
 
 module Variable : sig
 


### PR DESCRIPTION
@Khady @rr0gi, I am not sure how it worked before. Without this, resulting query contains `_esgg` which causes request to fail at runtime. Or am I missing something?