### PR TITLE
Add _shards to Search result type

### DIFF
--- a/derive.ml
+++ b/derive.ml
@@ -48,7 +48,8 @@ let output mapping query =
     let inner_hits_type = generate_inner_hits mapping source ?matched_queries inner_hits_specs in
     let hits = Hit.hits mapping ?inner_hits:inner_hits_type ~highlight ?fields ?matched_queries source in
     let aggs = List.map snd @@ snd @@ Aggregations.analyze mapping query in (* XXX discarding constraints *)
-    Dict (("hits", hits) :: (if aggs = [] then [] else ["aggregations", Dict aggs]))
+    let shards = Maybe (Dict ["total", Simple Int; "successful", Simple Int; "skipped", Simple Int; "failed", Simple Int]) in
+    Dict (("hits", hits) :: ("_shards", shards) :: (if aggs = [] then [] else ["aggregations", Dict aggs]))
 
 let print_reflect name mapping =
   let extern name = name ^ "_" in


### PR DESCRIPTION
## Summary
- Include shard info (`total`, `successful`, `skipped`, `failed`) as an optional field in the generated ATD result type for Search queries
- Enables typed access to shard failure data instead of manual JSON parsing in consumers
- Field is optional (`?_shards: _shards nullable`) so existing code only needs `; _` in pattern matches

## Context
ES can return HTTP 200 with partial results when some shards fail (e.g. memory limits). Currently consumers have to manually parse `_shards` from raw JSON before calling the ATD-generated parser, resulting in double parsing. With this change, `_shards` is part of the typed result.