### PR TITLE
Add failures array to _shards search result type

### DIFF
--- a/derive.ml
+++ b/derive.ml
@@ -48,7 +48,22 @@ let output mapping query =
     let inner_hits_type = generate_inner_hits mapping source ?matched_queries inner_hits_specs in
     let hits = Hit.hits mapping ?inner_hits:inner_hits_type ~highlight ?fields ?matched_queries source in
     let aggs = List.map snd @@ snd @@ Aggregations.analyze mapping query in (* XXX discarding constraints *)
-    let shards = Maybe (Dict ["total", Simple Int; "successful", Simple Int; "skipped", Simple Int; "failed", Simple Int]) in
+    let shards = Maybe (Dict [
+      "total", Simple Int;
+      "successful", Simple Int;
+      "skipped", Simple Int;
+      "failed", Simple Int;
+      "failures", Maybe (List (Dict [
+        "reason", Dict [
+          "type", Simple String;
+          "reason", Maybe (Simple String);
+        ];
+        "index", Maybe (Simple String);
+        "node", Maybe (Simple String);
+        "shard", Maybe (Simple Int);
+        "status", Maybe (Simple String);
+      ]));
+    ]) in
     Dict (("hits", hits) :: ("_shards", shards) :: (if aggs = [] then [] else ["aggregations", Dict aggs]))
 
 let print_reflect name mapping =

--- a/test/bucket_sort/output.atd
+++ b/test/bucket_sort/output.atd
@@ -11,7 +11,21 @@ type 'a value_agg =
 type basic_json <ocaml module="Json" t="t"> = abstract
 type hit = { _id: string; _source: basic_json }
 type hits = { total: int; ~hits: hit list }
-type _shards = { total: int; successful: int; skipped: int; failed: int }
+type reason = { type_ <json name="type">: string; ?reason: string nullable }
+type failure = {
+  reason: reason;
+  ?index: string nullable;
+  ?node: string nullable;
+  ?shard: int nullable;
+  ?status: string nullable
+}
+type _shards = {
+  total: int;
+  successful: int;
+  skipped: int;
+  failed: int;
+  ?failures: failure list nullable
+}
 type sales_per_month = {
   key: int;
   doc_count: int;

--- a/test/dynamic_filter_agg/output.atd
+++ b/test/dynamic_filter_agg/output.atd
@@ -16,7 +16,21 @@ type _source = {
 }
 type hit = { _id: string; _source: _source }
 type hits = { total: int; ~hits: hit list }
-type _shards = { total: int; successful: int; skipped: int; failed: int }
+type reason = { type_ <json name="type">: string; ?reason: string nullable }
+type failure = {
+  reason: reason;
+  ?index: string nullable;
+  ?node: string nullable;
+  ?shard: int nullable;
+  ?status: string nullable
+}
+type _shards = {
+  total: int;
+  successful: int;
+  skipped: int;
+  failed: int;
+  ?failures: failure list nullable
+}
 type latest_date = {
   ?value_as_string: string wrap <ocaml module="Publish_time"> nullable
 }

--- a/test/dynamic_source/output.atd
+++ b/test/dynamic_source/output.atd
@@ -11,5 +11,19 @@ type 'a value_agg =
 type basic_json <ocaml module="Json" t="t"> = abstract
 type hit = { _id: string; _source: basic_json }
 type hits = { total: int; ~hits: hit list }
-type _shards = { total: int; successful: int; skipped: int; failed: int }
+type reason = { type_ <json name="type">: string; ?reason: string nullable }
+type failure = {
+  reason: reason;
+  ?index: string nullable;
+  ?node: string nullable;
+  ?shard: int nullable;
+  ?status: string nullable
+}
+type _shards = {
+  total: int;
+  successful: int;
+  skipped: int;
+  failed: int;
+  ?failures: failure list nullable
+}
 type result = { hits: hits; ?_shards: _shards nullable }

--- a/test/esgg_inner_hits/output.atd
+++ b/test/esgg_inner_hits/output.atd
@@ -28,5 +28,19 @@ type hit1 = {
   ?inner_hits: inner_hits nullable
 }
 type hits1 = { total: int; ~hits: hit1 list }
-type _shards = { total: int; successful: int; skipped: int; failed: int }
+type reason = { type_ <json name="type">: string; ?reason: string nullable }
+type failure = {
+  reason: reason;
+  ?index: string nullable;
+  ?node: string nullable;
+  ?shard: int nullable;
+  ?status: string nullable
+}
+type _shards = {
+  total: int;
+  successful: int;
+  skipped: int;
+  failed: int;
+  ?failures: failure list nullable
+}
 type result = { hits: hits1; ?_shards: _shards nullable }

--- a/test/esgg_matched_queries/output.atd
+++ b/test/esgg_matched_queries/output.atd
@@ -20,5 +20,19 @@ type hit = {
   ?matched_queries: string list nullable
 }
 type hits = { total: int; ~hits: hit list }
-type _shards = { total: int; successful: int; skipped: int; failed: int }
+type reason = { type_ <json name="type">: string; ?reason: string nullable }
+type failure = {
+  reason: reason;
+  ?index: string nullable;
+  ?node: string nullable;
+  ?shard: int nullable;
+  ?status: string nullable
+}
+type _shards = {
+  total: int;
+  successful: int;
+  skipped: int;
+  failed: int;
+  ?failures: failure list nullable
+}
 type result = { hits: hits; ?_shards: _shards nullable }

--- a/test/fields/output.atd
+++ b/test/fields/output.atd
@@ -28,5 +28,19 @@ type highlight = {
 }
 type hit = { _id: string; _source: _source; ?highlight: highlight nullable }
 type hits = { total: int; ~hits: hit list }
-type _shards = { total: int; successful: int; skipped: int; failed: int }
+type reason = { type_ <json name="type">: string; ?reason: string nullable }
+type failure = {
+  reason: reason;
+  ?index: string nullable;
+  ?node: string nullable;
+  ?shard: int nullable;
+  ?status: string nullable
+}
+type _shards = {
+  total: int;
+  successful: int;
+  skipped: int;
+  failed: int;
+  ?failures: failure list nullable
+}
 type result = { hits: hits; ?_shards: _shards nullable }

--- a/test/filters_agg/output.atd
+++ b/test/filters_agg/output.atd
@@ -11,7 +11,21 @@ type 'a value_agg =
 type basic_json <ocaml module="Json" t="t"> = abstract
 type hit = { _id: string; _source: basic_json }
 type hits = { total: int; ~hits: hit list }
-type _shards = { total: int; successful: int; skipped: int; failed: int }
+type reason = { type_ <json name="type">: string; ?reason: string nullable }
+type failure = {
+  reason: reason;
+  ?index: string nullable;
+  ?node: string nullable;
+  ?shard: int nullable;
+  ?status: string nullable
+}
+type _shards = {
+  total: int;
+  successful: int;
+  skipped: int;
+  failed: int;
+  ?failures: failure list nullable
+}
 type errors = { doc_count: int }
 type buckets1 = { errors: errors; warnings: errors }
 type messages = { buckets: buckets1 }

--- a/test/function_score/output.atd
+++ b/test/function_score/output.atd
@@ -12,5 +12,19 @@ type basic_json <ocaml module="Json" t="t"> = abstract
 type _source = { content: string wrap <ocaml module="Content"> }
 type hit = { _id: string; _source: _source }
 type hits = { total: int; ~hits: hit list }
-type _shards = { total: int; successful: int; skipped: int; failed: int }
+type reason = { type_ <json name="type">: string; ?reason: string nullable }
+type failure = {
+  reason: reason;
+  ?index: string nullable;
+  ?node: string nullable;
+  ?shard: int nullable;
+  ?status: string nullable
+}
+type _shards = {
+  total: int;
+  successful: int;
+  skipped: int;
+  failed: int;
+  ?failures: failure list nullable
+}
 type result = { hits: hits; ?_shards: _shards nullable }

--- a/test/inner_hits/output.atd
+++ b/test/inner_hits/output.atd
@@ -28,5 +28,19 @@ type hit1 = {
   ?inner_hits: inner_hits nullable
 }
 type hits1 = { total: int; ~hits: hit1 list }
-type _shards = { total: int; successful: int; skipped: int; failed: int }
+type reason = { type_ <json name="type">: string; ?reason: string nullable }
+type failure = {
+  reason: reason;
+  ?index: string nullable;
+  ?node: string nullable;
+  ?shard: int nullable;
+  ?status: string nullable
+}
+type _shards = {
+  total: int;
+  successful: int;
+  skipped: int;
+  failed: int;
+  ?failures: failure list nullable
+}
 type result = { hits: hits1; ?_shards: _shards nullable }

--- a/test/many_optional/output.atd
+++ b/test/many_optional/output.atd
@@ -16,5 +16,19 @@ type _source = {
 }
 type hit = { _id: string; _source: _source }
 type hits = { total: int; ~hits: hit list }
-type _shards = { total: int; successful: int; skipped: int; failed: int }
+type reason = { type_ <json name="type">: string; ?reason: string nullable }
+type failure = {
+  reason: reason;
+  ?index: string nullable;
+  ?node: string nullable;
+  ?shard: int nullable;
+  ?status: string nullable
+}
+type _shards = {
+  total: int;
+  successful: int;
+  skipped: int;
+  failed: int;
+  ?failures: failure list nullable
+}
 type result = { hits: hits; ?_shards: _shards nullable }

--- a/test/multi_terms_agg/output.atd
+++ b/test/multi_terms_agg/output.atd
@@ -11,7 +11,21 @@ type 'a value_agg =
 type basic_json <ocaml module="Json" t="t"> = abstract
 type hit = { _id: string; _source: basic_json }
 type hits = { total: int; ~hits: hit list }
-type _shards = { total: int; successful: int; skipped: int; failed: int }
+type reason = { type_ <json name="type">: string; ?reason: string nullable }
+type failure = {
+  reason: reason;
+  ?index: string nullable;
+  ?node: string nullable;
+  ?shard: int nullable;
+  ?status: string nullable
+}
+type _shards = {
+  total: int;
+  successful: int;
+  skipped: int;
+  failed: int;
+  ?failures: failure list nullable
+}
 type aggregations = {
   genres_and_products:
     (

--- a/test/named_queries/output.atd
+++ b/test/named_queries/output.atd
@@ -20,5 +20,19 @@ type hit = {
   ?matched_queries: string list nullable
 }
 type hits = { total: int; ~hits: hit list }
-type _shards = { total: int; successful: int; skipped: int; failed: int }
+type reason = { type_ <json name="type">: string; ?reason: string nullable }
+type failure = {
+  reason: reason;
+  ?index: string nullable;
+  ?node: string nullable;
+  ?shard: int nullable;
+  ?status: string nullable
+}
+type _shards = {
+  total: int;
+  successful: int;
+  skipped: int;
+  failed: int;
+  ?failures: failure list nullable
+}
 type result = { hits: hits; ?_shards: _shards nullable }

--- a/test/nested/output.atd
+++ b/test/nested/output.atd
@@ -19,5 +19,19 @@ type _source = {
 }
 type hit = { _id: string; _source: _source }
 type hits = { total: int; ~hits: hit list }
-type _shards = { total: int; successful: int; skipped: int; failed: int }
+type reason = { type_ <json name="type">: string; ?reason: string nullable }
+type failure = {
+  reason: reason;
+  ?index: string nullable;
+  ?node: string nullable;
+  ?shard: int nullable;
+  ?status: string nullable
+}
+type _shards = {
+  total: int;
+  successful: int;
+  skipped: int;
+  failed: int;
+  ?failures: failure list nullable
+}
 type result = { hits: hits; ?_shards: _shards nullable }

--- a/test/other_bucket/output.atd
+++ b/test/other_bucket/output.atd
@@ -11,9 +11,23 @@ type 'a value_agg =
 type basic_json <ocaml module="Json" t="t"> = abstract
 type hit = { _id: string; _source: basic_json }
 type hits = { total: int; ~hits: hit list }
-type _shards = { total: int; successful: int; skipped: int; failed: int }
-type failure = { doc_count: int; count: int_as_float value_agg }
-type buckets1 = { failure: failure; success: failure }
+type reason = { type_ <json name="type">: string; ?reason: string nullable }
+type failure = {
+  reason: reason;
+  ?index: string nullable;
+  ?node: string nullable;
+  ?shard: int nullable;
+  ?status: string nullable
+}
+type _shards = {
+  total: int;
+  successful: int;
+  skipped: int;
+  failed: int;
+  ?failures: failure list nullable
+}
+type failure1 = { doc_count: int; count: int_as_float value_agg }
+type buckets1 = { failure: failure1; success: failure1 }
 type by_result = { buckets: buckets1 }
 type by_event = {
   key: string wrap <ocaml module="Event">;

--- a/test/query_string/output.atd
+++ b/test/query_string/output.atd
@@ -12,5 +12,19 @@ type basic_json <ocaml module="Json" t="t"> = abstract
 type _source = { content: string wrap <ocaml module="Content"> }
 type hit = { _id: string; _source: _source }
 type hits = { total: int; ~hits: hit list }
-type _shards = { total: int; successful: int; skipped: int; failed: int }
+type reason = { type_ <json name="type">: string; ?reason: string nullable }
+type failure = {
+  reason: reason;
+  ?index: string nullable;
+  ?node: string nullable;
+  ?shard: int nullable;
+  ?status: string nullable
+}
+type _shards = {
+  total: int;
+  successful: int;
+  skipped: int;
+  failed: int;
+  ?failures: failure list nullable
+}
 type result = { hits: hits; ?_shards: _shards nullable }

--- a/test/range_agg/output.atd
+++ b/test/range_agg/output.atd
@@ -16,7 +16,21 @@ type _source = {
 }
 type hit = { _id: string; _source: _source }
 type hits = { total: int; ~hits: hit list }
-type _shards = { total: int; successful: int; skipped: int; failed: int }
+type reason = { type_ <json name="type">: string; ?reason: string nullable }
+type failure = {
+  reason: reason;
+  ?index: string nullable;
+  ?node: string nullable;
+  ?shard: int nullable;
+  ?status: string nullable
+}
+type _shards = {
+  total: int;
+  successful: int;
+  skipped: int;
+  failed: int;
+  ?failures: failure list nullable
+}
 type bucket = {
   key: string wrap <ocaml module="Content">;
   doc_count: int;

--- a/test/range_params/output.atd
+++ b/test/range_params/output.atd
@@ -16,5 +16,19 @@ type _source = {
 }
 type hit = { _id: string; _source: _source }
 type hits = { total: int; ~hits: hit list }
-type _shards = { total: int; successful: int; skipped: int; failed: int }
+type reason = { type_ <json name="type">: string; ?reason: string nullable }
+type failure = {
+  reason: reason;
+  ?index: string nullable;
+  ?node: string nullable;
+  ?shard: int nullable;
+  ?status: string nullable
+}
+type _shards = {
+  total: int;
+  successful: int;
+  skipped: int;
+  failed: int;
+  ?failures: failure list nullable
+}
 type result = { hits: hits; ?_shards: _shards nullable }

--- a/test/reverse_nested_agg/output.atd
+++ b/test/reverse_nested_agg/output.atd
@@ -21,7 +21,21 @@ type _source = {
 }
 type hit = { _id: string; _source: _source }
 type hits = { total: int; ~hits: hit list }
-type _shards = { total: int; successful: int; skipped: int; failed: int }
+type reason = { type_ <json name="type">: string; ?reason: string nullable }
+type failure = {
+  reason: reason;
+  ?index: string nullable;
+  ?node: string nullable;
+  ?shard: int nullable;
+  ?status: string nullable
+}
+type _shards = {
+  total: int;
+  successful: int;
+  skipped: int;
+  failed: int;
+  ?failures: failure list nullable
+}
 type name = { name: string wrap <ocaml module="Name"> }
 type hit1 = { _id: string; _source: name }
 type hits1 = { total: int; ~hits: hit1 list }

--- a/test/size/output.atd
+++ b/test/size/output.atd
@@ -12,5 +12,19 @@ type basic_json <ocaml module="Json" t="t"> = abstract
 type _source = { content: string wrap <ocaml module="Content"> }
 type hit = { _id: string; _source: _source }
 type hits = { total: int; ~hits: hit list }
-type _shards = { total: int; successful: int; skipped: int; failed: int }
+type reason = { type_ <json name="type">: string; ?reason: string nullable }
+type failure = {
+  reason: reason;
+  ?index: string nullable;
+  ?node: string nullable;
+  ?shard: int nullable;
+  ?status: string nullable
+}
+type _shards = {
+  total: int;
+  successful: int;
+  skipped: int;
+  failed: int;
+  ?failures: failure list nullable
+}
 type result = { hits: hits; ?_shards: _shards nullable }

--- a/test/stored_fields/output.atd
+++ b/test/stored_fields/output.atd
@@ -16,5 +16,19 @@ type fields = {
 }
 type hit = { _id: string; _source: _source; fields: fields }
 type hits = { total: int; ~hits: hit list }
-type _shards = { total: int; successful: int; skipped: int; failed: int }
+type reason = { type_ <json name="type">: string; ?reason: string nullable }
+type failure = {
+  reason: reason;
+  ?index: string nullable;
+  ?node: string nullable;
+  ?shard: int nullable;
+  ?status: string nullable
+}
+type _shards = {
+  total: int;
+  successful: int;
+  skipped: int;
+  failed: int;
+  ?failures: failure list nullable
+}
 type result = { hits: hits; ?_shards: _shards nullable }

--- a/test/var_filter/output.atd
+++ b/test/var_filter/output.atd
@@ -12,5 +12,19 @@ type basic_json <ocaml module="Json" t="t"> = abstract
 type _source = { content: string wrap <ocaml module="Content"> }
 type hit = { _id: string; _source: _source }
 type hits = { total: int; ~hits: hit list }
-type _shards = { total: int; successful: int; skipped: int; failed: int }
+type reason = { type_ <json name="type">: string; ?reason: string nullable }
+type failure = {
+  reason: reason;
+  ?index: string nullable;
+  ?node: string nullable;
+  ?shard: int nullable;
+  ?status: string nullable
+}
+type _shards = {
+  total: int;
+  successful: int;
+  skipped: int;
+  failed: int;
+  ?failures: failure list nullable
+}
 type result = { hits: hits; ?_shards: _shards nullable }

--- a/test/weighted_avg/output.atd
+++ b/test/weighted_avg/output.atd
@@ -11,7 +11,21 @@ type 'a value_agg =
 type basic_json <ocaml module="Json" t="t"> = abstract
 type hit = { _id: string; _source: basic_json }
 type hits = { total: int; ~hits: hit list }
-type _shards = { total: int; successful: int; skipped: int; failed: int }
+type reason = { type_ <json name="type">: string; ?reason: string nullable }
+type failure = {
+  reason: reason;
+  ?index: string nullable;
+  ?node: string nullable;
+  ?shard: int nullable;
+  ?status: string nullable
+}
+type _shards = {
+  total: int;
+  successful: int;
+  skipped: int;
+  failed: int;
+  ?failures: failure list nullable
+}
 type aggregations = { weighted_grade: float nullable value_agg }
 type result = {
   hits: hits;


### PR DESCRIPTION
## Summary

- Extends the generated `_shards` ATD type for Search queries to include the `failures` array
- Enables typed access to shard failure details: reason text, shard number, index, node, status
- Matches the official ES spec: [ShardStatistics](https://github.com/elastic/elasticsearch-specification/blob/main/specification/_types/Stats.ts) + [ShardFailure / ErrorCause](https://github.com/elastic/elasticsearch-specification/blob/main/specification/_types/Errors.ts)

## Generated type change

Before:
```
type _shards = { total: int; successful: int; skipped: int; failed: int }
```

After:
```
type reason = { type_ <json name="type">: string; ?reason: string nullable }
type failure = { reason: reason; ?index: string nullable; ?node: string nullable; ?shard: int nullable; ?status: string nullable }
type _shards = { total: int; successful: int; skipped: int; failed: int; ?failures: failure list nullable }
```

## Optionality follows the spec

- `failures` is **optional** on `_shards` — may be absent even when `failed > 0`
- `reason` is **required** on each failure entry
- `reason.type` is **required**; `reason.reason` (human-readable text) is **optional**
- `shard`, `index`, `node`, `status` are all **optional**
- `type` → `type_` in OCaml (keyword escape) with `<json name="type">` annotation

## Test impact

All 22 search query `output.atd` snapshots updated. Get/Mget tests unaffected.

Note: `other_bucket` test correctly handles a pre-existing `failure` type name from its aggregations — the shard `failure` type takes the name, and the aggregation type is automatically renamed to `failure1`.