### PR TITLE
Fix min/max on integer fields returning float parse errors

### DIFF
--- a/aggregations.ml
+++ b/aggregations.ml
@@ -268,7 +268,12 @@ let infer_single mapping ~nested { name; agg; } sibling sub =
       let typ =
         match metric with
 (*         | `MinMax -> `Maybe (`Typeof value) *)
-        | `MinMax -> Maybe value_type (* TODO use Typeof, but need meta annotation to fallback to value_type *)
+        | `MinMax ->
+          (* ES min/max returns doubles even on integer fields, same as sum *)
+          begin match value_type with
+          | Simple (Int | Int64 as t) | Ref (_, (Int | Int64 as t)) -> Maybe (Dict ["override int as float hack", Simple t])
+          | _ -> Maybe value_type
+          end
         | `Avg -> Maybe double
         | `Sum ->
           match value_type with

--- a/atdgen.ml
+++ b/atdgen.ml
@@ -322,6 +322,7 @@ let add_shape t name shape =
     | Dict ["key",k; "doc_count", Simple Int] -> pname "doc_count" [map k]
     | Dict ["buckets", List t] -> pname "buckets" [map t]
     | Dict ["value", Dict ["override int as float hack", Simple Int]] -> pname "value_agg" [tname "int_as_float"]
+    | Dict ["value", Maybe (Dict ["override int as float hack", Simple Int])] -> pname "value_agg" [nullable (tname "int_as_float")]
     | Dict ["value", t] -> pname "value_agg" [map t]
 (*     | Dict ["value_as_string", t] -> pname "value_as_string_agg" [map t] *)
     | Dict fields -> safe_record map fields


### PR DESCRIPTION
ES min/max aggregations return doubles even on long/integer fields (e.g. 12345.0 instead of 12345), same as sum. The sum case already handles this with the "int as float hack" that generates a wrapper type to parse the float and convert to int. Apply the same fix to min/max.

Without this fix, using min/max on a long field generates an int parser that crashes on the .0 decimal in the ES response.