### PR TITLE
add took to Search result type

### DIFF
--- a/derive.ml
+++ b/derive.ml
@@ -64,7 +64,11 @@ let output mapping query =
         "status", Maybe (Simple String);
       ]));
     ]) in
-    Dict (("hits", hits) :: ("_shards", shards) :: (if aggs = [] then [] else ["aggregations", Dict aggs]))
+    Dict
+      (("took", Maybe (Simple Int))
+      :: ("hits", hits)
+      :: ("_shards", shards)
+      :: (if aggs = [] then [] else [ "aggregations", Dict aggs ]))
 
 let print_reflect name mapping =
   let extern name = name ^ "_" in

--- a/test/bucket_sort/output.atd
+++ b/test/bucket_sort/output.atd
@@ -34,6 +34,7 @@ type sales_per_month = {
 }
 type aggregations = { sales_per_month: sales_per_month buckets }
 type result = {
+  ?took: int nullable;
   hits: hits;
   ?_shards: _shards nullable;
   aggregations: aggregations

--- a/test/composite/output.atd
+++ b/test/composite/output.atd
@@ -33,6 +33,7 @@ type my_buckets = {
 }
 type aggregations = { my_buckets: my_buckets }
 type result = {
+  ?took: int nullable;
   hits: hits;
   ?_shards: _shards nullable;
   aggregations: aggregations

--- a/test/composite_date_histogram/output.atd
+++ b/test/composite_date_histogram/output.atd
@@ -33,6 +33,7 @@ type my_buckets = {
 }
 type aggregations = { my_buckets: my_buckets }
 type result = {
+  ?took: int nullable;
   hits: hits;
   ?_shards: _shards nullable;
   aggregations: aggregations

--- a/test/composite_geotile/output.atd
+++ b/test/composite_geotile/output.atd
@@ -33,6 +33,7 @@ type my_buckets = {
 }
 type aggregations = { my_buckets: my_buckets }
 type result = {
+  ?took: int nullable;
   hits: hits;
   ?_shards: _shards nullable;
   aggregations: aggregations

--- a/test/composite_histogram/output.atd
+++ b/test/composite_histogram/output.atd
@@ -36,6 +36,7 @@ type my_buckets = {
 }
 type aggregations = { my_buckets: my_buckets }
 type result = {
+  ?took: int nullable;
   hits: hits;
   ?_shards: _shards nullable;
   aggregations: aggregations

--- a/test/composite_multi_sources/output.atd
+++ b/test/composite_multi_sources/output.atd
@@ -37,6 +37,7 @@ type my_buckets = {
 }
 type aggregations = { my_buckets: my_buckets }
 type result = {
+  ?took: int nullable;
   hits: hits;
   ?_shards: _shards nullable;
   aggregations: aggregations

--- a/test/composite_subaggs/output.atd
+++ b/test/composite_subaggs/output.atd
@@ -31,6 +31,7 @@ type bucket = { key: key; doc_count: int; the_avg: float nullable value_agg }
 type my_buckets = { ?after_key: basic_json nullable; ~buckets: bucket list }
 type aggregations = { my_buckets: my_buckets }
 type result = {
+  ?took: int nullable;
   hits: hits;
   ?_shards: _shards nullable;
   aggregations: aggregations

--- a/test/dynamic_filter_agg/output.atd
+++ b/test/dynamic_filter_agg/output.atd
@@ -46,6 +46,7 @@ type buckets1 = { words10: words10; wordsn: words10 }
 type target = { buckets: buckets1 }
 type aggregations = { target: target }
 type result = {
+  ?took: int nullable;
   hits: hits;
   ?_shards: _shards nullable;
   aggregations: aggregations

--- a/test/dynamic_source/output.atd
+++ b/test/dynamic_source/output.atd
@@ -26,4 +26,4 @@ type _shards = {
   failed: int;
   ?failures: failure list nullable
 }
-type result = { hits: hits; ?_shards: _shards nullable }
+type result = { ?took: int nullable; hits: hits; ?_shards: _shards nullable }

--- a/test/esgg_inner_hits/output.atd
+++ b/test/esgg_inner_hits/output.atd
@@ -43,4 +43,8 @@ type _shards = {
   failed: int;
   ?failures: failure list nullable
 }
-type result = { hits: hits1; ?_shards: _shards nullable }
+type result = {
+  ?took: int nullable;
+  hits: hits1;
+  ?_shards: _shards nullable
+}

--- a/test/esgg_matched_queries/output.atd
+++ b/test/esgg_matched_queries/output.atd
@@ -35,4 +35,4 @@ type _shards = {
   failed: int;
   ?failures: failure list nullable
 }
-type result = { hits: hits; ?_shards: _shards nullable }
+type result = { ?took: int nullable; hits: hits; ?_shards: _shards nullable }

--- a/test/field_var_agg/output.atd
+++ b/test/field_var_agg/output.atd
@@ -28,6 +28,7 @@ type _shards = {
 }
 type aggregations = { grouped: string doc_count buckets }
 type result = {
+  ?took: int nullable;
   hits: hits;
   ?_shards: _shards nullable;
   aggregations: aggregations

--- a/test/field_var_histogram/output.atd
+++ b/test/field_var_histogram/output.atd
@@ -28,6 +28,7 @@ type _shards = {
 }
 type aggregations = { distribution: float doc_count buckets }
 type result = {
+  ?took: int nullable;
   hits: hits;
   ?_shards: _shards nullable;
   aggregations: aggregations

--- a/test/fields/output.atd
+++ b/test/fields/output.atd
@@ -43,4 +43,4 @@ type _shards = {
   failed: int;
   ?failures: failure list nullable
 }
-type result = { hits: hits; ?_shards: _shards nullable }
+type result = { ?took: int nullable; hits: hits; ?_shards: _shards nullable }

--- a/test/filters_agg/output.atd
+++ b/test/filters_agg/output.atd
@@ -31,6 +31,7 @@ type buckets1 = { errors: errors; warnings: errors }
 type messages = { buckets: buckets1 }
 type aggregations = { messages: messages; messages_list: errors buckets }
 type result = {
+  ?took: int nullable;
   hits: hits;
   ?_shards: _shards nullable;
   aggregations: aggregations

--- a/test/function_score/output.atd
+++ b/test/function_score/output.atd
@@ -27,4 +27,4 @@ type _shards = {
   failed: int;
   ?failures: failure list nullable
 }
-type result = { hits: hits; ?_shards: _shards nullable }
+type result = { ?took: int nullable; hits: hits; ?_shards: _shards nullable }

--- a/test/highlight_optional_parent/output.atd
+++ b/test/highlight_optional_parent/output.atd
@@ -52,4 +52,4 @@ type _shards = {
   failed: int;
   ?failures: failure list nullable
 }
-type result = { hits: hits; ?_shards: _shards nullable }
+type result = { ?took: int nullable; hits: hits; ?_shards: _shards nullable }

--- a/test/inner_hits/output.atd
+++ b/test/inner_hits/output.atd
@@ -43,4 +43,8 @@ type _shards = {
   failed: int;
   ?failures: failure list nullable
 }
-type result = { hits: hits1; ?_shards: _shards nullable }
+type result = {
+  ?took: int nullable;
+  hits: hits1;
+  ?_shards: _shards nullable
+}

--- a/test/many_optional/output.atd
+++ b/test/many_optional/output.atd
@@ -31,4 +31,4 @@ type _shards = {
   failed: int;
   ?failures: failure list nullable
 }
-type result = { hits: hits; ?_shards: _shards nullable }
+type result = { ?took: int nullable; hits: hits; ?_shards: _shards nullable }

--- a/test/multi_terms_agg/output.atd
+++ b/test/multi_terms_agg/output.atd
@@ -39,6 +39,7 @@ type aggregations = {
     ) doc_count buckets
 }
 type result = {
+  ?took: int nullable;
   hits: hits;
   ?_shards: _shards nullable;
   aggregations: aggregations

--- a/test/named_queries/output.atd
+++ b/test/named_queries/output.atd
@@ -35,4 +35,4 @@ type _shards = {
   failed: int;
   ?failures: failure list nullable
 }
-type result = { hits: hits; ?_shards: _shards nullable }
+type result = { ?took: int nullable; hits: hits; ?_shards: _shards nullable }

--- a/test/nested/output.atd
+++ b/test/nested/output.atd
@@ -34,4 +34,4 @@ type _shards = {
   failed: int;
   ?failures: failure list nullable
 }
-type result = { hits: hits; ?_shards: _shards nullable }
+type result = { ?took: int nullable; hits: hits; ?_shards: _shards nullable }

--- a/test/other_bucket/output.atd
+++ b/test/other_bucket/output.atd
@@ -36,6 +36,7 @@ type by_event = {
 }
 type aggregations = { by_event: by_event buckets }
 type result = {
+  ?took: int nullable;
   hits: hits;
   ?_shards: _shards nullable;
   aggregations: aggregations

--- a/test/query_string/output.atd
+++ b/test/query_string/output.atd
@@ -27,4 +27,4 @@ type _shards = {
   failed: int;
   ?failures: failure list nullable
 }
-type result = { hits: hits; ?_shards: _shards nullable }
+type result = { ?took: int nullable; hits: hits; ?_shards: _shards nullable }

--- a/test/range_agg/output.atd
+++ b/test/range_agg/output.atd
@@ -50,6 +50,7 @@ type w = { buckets: buckets1 }
 type w_over_time = { key: int; doc_count: int; key_as_string: string; w: w }
 type aggregations = { keywords: keywords; w_over_time: w_over_time buckets }
 type result = {
+  ?took: int nullable;
   hits: hits;
   ?_shards: _shards nullable;
   aggregations: aggregations

--- a/test/range_params/output.atd
+++ b/test/range_params/output.atd
@@ -31,4 +31,4 @@ type _shards = {
   failed: int;
   ?failures: failure list nullable
 }
-type result = { hits: hits; ?_shards: _shards nullable }
+type result = { ?took: int nullable; hits: hits; ?_shards: _shards nullable }

--- a/test/reverse_nested_agg/output.atd
+++ b/test/reverse_nested_agg/output.atd
@@ -68,6 +68,7 @@ type into_obj = {
 }
 type aggregations = { into_obj: into_obj }
 type result = {
+  ?took: int nullable;
   hits: hits;
   ?_shards: _shards nullable;
   aggregations: aggregations

--- a/test/size/output.atd
+++ b/test/size/output.atd
@@ -27,4 +27,4 @@ type _shards = {
   failed: int;
   ?failures: failure list nullable
 }
-type result = { hits: hits; ?_shards: _shards nullable }
+type result = { ?took: int nullable; hits: hits; ?_shards: _shards nullable }

--- a/test/stored_fields/output.atd
+++ b/test/stored_fields/output.atd
@@ -31,4 +31,4 @@ type _shards = {
   failed: int;
   ?failures: failure list nullable
 }
-type result = { hits: hits; ?_shards: _shards nullable }
+type result = { ?took: int nullable; hits: hits; ?_shards: _shards nullable }

--- a/test/var_filter/output.atd
+++ b/test/var_filter/output.atd
@@ -27,4 +27,4 @@ type _shards = {
   failed: int;
   ?failures: failure list nullable
 }
-type result = { hits: hits; ?_shards: _shards nullable }
+type result = { ?took: int nullable; hits: hits; ?_shards: _shards nullable }

--- a/test/weighted_avg/output.atd
+++ b/test/weighted_avg/output.atd
@@ -28,6 +28,7 @@ type _shards = {
 }
 type aggregations = { weighted_grade: float nullable value_agg }
 type result = {
+  ?took: int nullable;
   hits: hits;
   ?_shards: _shards nullable;
   aggregations: aggregations


### PR DESCRIPTION
Include took (ES server-side execution time, ms) as an optional field in the generated ATD result type for Search queries

before:
```
type result = { hits: hits; ?_shards: _shards nullable }
```

after:
```
type result = { ?took: int nullable; hits: hits; ?_shards: _shards nullable }
```