### PR TITLE
regenerate optional_object_members test

### DIFF
--- a/test/optional_object_members/output.atd
+++ b/test/optional_object_members/output.atd
@@ -31,4 +31,4 @@ type _shards = {
   failed: int;
   ?failures: failure list nullable
 }
-type result = { hits: hits; ?_shards: _shards nullable }
+type result = { ?took: int nullable; hits: hits; ?_shards: _shards nullable }


### PR DESCRIPTION
Regenerate optional_object_members test output

#22 (took) and the optional-members fix were developed in parallel from the same base. The optional_object_members test was generated before #22 merged, so it misses the `?took` field and `make test` fails on master.